### PR TITLE
Token module adjustment

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -256,6 +256,7 @@ impl sudo::Trait for Runtime {
 
 /// Used for the module token in `./token.rs`
 impl token::Trait for Runtime {
+	type TokenBalance = Balance;
 	type Event = Event;
 }
 
@@ -279,7 +280,7 @@ construct_runtime!(
 		Balances: balances,
 		Sudo: sudo,
 		// Used for the module token in `./token.rs`
-		Token: token::{Module, Call, Storage, Event<T>},
+		Token: token::{Module, Call, Storage, Config<T>, Event<T>},
 		Bancor: bancor::{Module, Call, Storage, Event<T>},
 	}
 );

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -1,7 +1,7 @@
 use primitives::{Pair, Public};
 use bandot_node_runtime::{
 	AccountId, BabeConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
-	SudoConfig, IndicesConfig, SystemConfig, WASM_BINARY, 
+	SudoConfig, IndicesConfig, SystemConfig, TokenConfig, WASM_BINARY, 
 };
 use babe_primitives::{AuthorityId as BabeId};
 use grandpa_primitives::{AuthorityId as GrandpaId};
@@ -123,13 +123,17 @@ fn testnet_genesis(initial_authorities: Vec<(AccountId, AccountId, GrandpaId, Ba
 			vesting: vec![],
 		}),
 		sudo: Some(SudoConfig {
-			key: root_key,
+			key: root_key.clone(),
 		}),
 		babe: Some(BabeConfig {
 			authorities: initial_authorities.iter().map(|x| (x.3.clone(), 1)).collect(),
 		}),
 		grandpa: Some(GrandpaConfig {
 			authorities: initial_authorities.iter().map(|x| (x.2.clone(), 1)).collect(),
+		}),
+		token: Some(TokenConfig {
+			owner: root_key,
+			circulation: 0,
 		}),
 	}
 }


### PR DESCRIPTION
1. Add init check to token module.
2. Rename `admin` to `owner` according to the erc20 convention.
3. extract `circulation` and `owner` init-value to genesis config.